### PR TITLE
Add support for compiling on vanilla mipsel GCC toolchain

### DIFF
--- a/usb/include/usb_cdc.h
+++ b/usb/include/usb_cdc.h
@@ -39,7 +39,7 @@
 #include <stdint.h>
 #include "usb_config.h"
 
-#if defined(__XC16__) || defined(__XC32__)
+#if defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 #pragma pack(push, 1)
 #elif __XC8
 #else
@@ -488,7 +488,7 @@ extern int8_t CDC_SEND_BREAK_CALLBACK(uint8_t interface, uint16_t duration);
 /** @}*/
 
 
-#if defined(__XC16__) || defined(__XC32__)
+#if defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 #pragma pack(pop)
 #elif __XC8
 #else

--- a/usb/include/usb_ch9.h
+++ b/usb/include/usb_ch9.h
@@ -38,7 +38,7 @@
 
 #include <stdint.h>
 
-#if defined(__XC16__) || defined(__XC32__)
+#if defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 #pragma pack(push, 1)
 #elif __XC8
 #else
@@ -273,7 +273,7 @@ struct interface_association_descriptor {
 /** @endcond */
 
 
-#if defined(__XC16__) || defined(__XC32__)
+#if defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 #pragma pack(pop)
 #elif __XC8
 #else

--- a/usb/include/usb_hid.h
+++ b/usb/include/usb_hid.h
@@ -39,7 +39,7 @@
 #include <stdint.h>
 #include "usb_config.h"
 
-#if defined(__XC16__) || defined(__XC32__)
+#if defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 #pragma pack(push, 1)
 #elif __XC8
 #else
@@ -333,7 +333,7 @@ uint8_t process_hid_setup_request(const struct setup_packet *setup);
 /** @}*/
 
 
-#if defined(__XC16__) || defined(__XC32__)
+#if defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 #pragma pack(pop)
 #elif __XC8
 #else

--- a/usb/include/usb_microsoft.h
+++ b/usb/include/usb_microsoft.h
@@ -38,7 +38,7 @@
 
 #include <stdint.h>
 
-#if defined(__XC16__) || defined(__XC32__)
+#if defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 #pragma pack(push, 1)
 #elif __XC8
 #else
@@ -171,7 +171,7 @@ uint16_t MICROSOFT_CUSTOM_PROPERTY_DESCRIPTOR_FUNC(uint8_t interface,
 /* Doxygen end-of-group for microsoft_items */
 /** @}*/
 
-#if defined(__XC16__) || defined(__XC32__)
+#if defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 #pragma pack(pop)
 #elif __XC8
 #else

--- a/usb/include/usb_msc.h
+++ b/usb/include/usb_msc.h
@@ -39,7 +39,7 @@
 #include <stdint.h>
 #include "usb_config.h"
 
-#if defined(__XC16__) || defined(__XC32__)
+#if defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 #pragma pack(push, 1)
 #elif __XC8
 #else
@@ -299,7 +299,7 @@ struct scsi_sense_response {
 	/* Additional, vendor-specific sense data goes here. */
 };
 
-#if defined(__XC16__) || defined(__XC32__)
+#if defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 #pragma pack(pop)
 #elif __XC8
 #else

--- a/usb/src/usb.c
+++ b/usb/src/usb.c
@@ -36,6 +36,8 @@
 #include <delays.h>
 #elif __XC8
 #include <xc.h>
+#elif __GNUC__
+#include <xc.h>
 #else
 #error "Compiler not supported"
 #endif

--- a/usb/src/usb.c
+++ b/usb/src/usb.c
@@ -36,8 +36,8 @@
 #include <delays.h>
 #elif __XC8
 #include <xc.h>
-#elif __GNUC__
-#include <xc.h>
+#elif defined(__GNUC__) && __mips == 32
+    /* You need to have an include in usb_config.h. */
 #else
 #error "Compiler not supported"
 #endif
@@ -118,7 +118,7 @@ STATIC_SIZE_CHECK_EQUAL(sizeof(struct microsoft_extended_compat_header), 16);
 STATIC_SIZE_CHECK_EQUAL(sizeof(struct microsoft_extended_compat_function), 24);
 STATIC_SIZE_CHECK_EQUAL(sizeof(struct microsoft_extended_properties_header), 10);
 STATIC_SIZE_CHECK_EQUAL(sizeof(struct microsoft_extended_property_section_header), 8);
-#ifdef __XC32__
+#if defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 STATIC_SIZE_CHECK_EQUAL(sizeof(struct buffer_descriptor), 8);
 #else
 STATIC_SIZE_CHECK_EQUAL(sizeof(struct buffer_descriptor), 4);
@@ -207,7 +207,7 @@ static struct buffer_descriptor bds[NUM_BD] BD_ATTR_TAG;
    0x400 and 0x7FF per the datasheet.*/
 /* This addr is for the PIC18F4550 */
 #pragma udata usb_buffers=0x500
-#elif defined(__XC16__) || defined(__XC32__)
+#elif defined(__XC16__) || defined(__XC32__) || (defined(__GNUC__) && __mips == 32)
 	/* Buffers can go anywhere on PIC24/PIC32 parts which are supported
 	   (so far). */
 #elif __XC8
@@ -625,7 +625,7 @@ void usb_init(void)
 
 	SFR_BD_ADDR_REG = w.hb;
 
-#elif __XC32__
+#elif __XC32__ || (defined(__GNUC__) && __mips == 32)
 	union WORD {
 		struct {
 			uint8_t lb;
@@ -1694,7 +1694,7 @@ void _ISR __attribute((auto_psv)) _USB1Interrupt()
 	usb_service();
 }
 
-#elif __XC32__
+#elif __XC32__ || (defined(__GNUC__) && __mips == 32)
 
 /* No parameter for interrupt() means to use IPL=RIPL and to detect whether
    to use shadow registers or not. This is the safest option, but if a user

--- a/usb/src/usb_cdc.c
+++ b/usb/src/usb_cdc.c
@@ -159,7 +159,7 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 			return -1;
 
 		usb_send_data_stage((void*)response,
-		                    min(len, setup->wLength),
+		                    MIN(len, setup->wLength),
 		                    callback, context);
 		return 0;
 	}
@@ -227,7 +227,7 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 				(uint16_t) data_multiplexed_state << 1;
 
 		usb_send_data_stage((char*)&transfer_data.comm_feature,
-		                    min(setup->wLength,
+		                    MIN(setup->wLength,
 		                        sizeof(transfer_data.comm_feature)),
 		                    NULL/*callback*/, NULL);
 		return 0;
@@ -241,7 +241,7 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 		transfer_interface = interface;
 		usb_start_receive_ep0_data_stage(
 		                      (char*)&transfer_data.line_coding,
-		                      min(setup->wLength,
+		                      MIN(setup->wLength,
 		                          sizeof(transfer_data.line_coding)),
 		                      set_line_coding, NULL);
 		return 0;
@@ -260,7 +260,7 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 			return -1;
 
 		usb_send_data_stage((char*)&transfer_data.line_coding,
-		                    min(setup->wLength,
+		                    MIN(setup->wLength,
 		                        sizeof(transfer_data.line_coding)),
 		                    /*callback*/NULL, NULL);
 		return 0;

--- a/usb/src/usb_cdc.c
+++ b/usb/src/usb_cdc.c
@@ -159,7 +159,7 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 			return -1;
 
 		usb_send_data_stage((void*)response,
-		                    min(len, setup->wLength),
+                            (len<setup->wLength)? len : setup->wLength,
 		                    callback, context);
 		return 0;
 	}
@@ -227,8 +227,8 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 				(uint16_t) data_multiplexed_state << 1;
 
 		usb_send_data_stage((char*)&transfer_data.comm_feature,
-		                    min(setup->wLength,
-		                        sizeof(transfer_data.comm_feature)),
+                            (setup->wLength<sizeof(transfer_data.comm_feature))?
+		                    setup->wLength : sizeof(transfer_data.comm_feature)
 		                    NULL/*callback*/, NULL);
 		return 0;
 	}
@@ -241,8 +241,8 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 		transfer_interface = interface;
 		usb_start_receive_ep0_data_stage(
 		                      (char*)&transfer_data.line_coding,
-		                      min(setup->wLength,
-		                          sizeof(transfer_data.line_coding)),
+                              (setup->wLength<sizeof(transfer_data.comm_feature))?
+                                  setup->wLength : sizeof(transfer_data.comm_feature)
 		                      set_line_coding, NULL);
 		return 0;
 	}
@@ -260,8 +260,8 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 			return -1;
 
 		usb_send_data_stage((char*)&transfer_data.line_coding,
-		                    min(setup->wLength,
-		                        sizeof(transfer_data.line_coding)),
+                            (setup->wLength<sizeof(transfer_data.comm_feature))?
+                                setup->wLength : sizeof(transfer_data.comm_feature)
 		                    /*callback*/NULL, NULL);
 		return 0;
 	}

--- a/usb/src/usb_cdc.c
+++ b/usb/src/usb_cdc.c
@@ -159,7 +159,7 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 			return -1;
 
 		usb_send_data_stage((void*)response,
-                            (len<setup->wLength)? len : setup->wLength,
+		                    min(len, setup->wLength),
 		                    callback, context);
 		return 0;
 	}
@@ -227,8 +227,8 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 				(uint16_t) data_multiplexed_state << 1;
 
 		usb_send_data_stage((char*)&transfer_data.comm_feature,
-                            (setup->wLength<sizeof(transfer_data.comm_feature))?
-		                    setup->wLength : sizeof(transfer_data.comm_feature)
+		                    min(setup->wLength,
+		                        sizeof(transfer_data.comm_feature)),
 		                    NULL/*callback*/, NULL);
 		return 0;
 	}
@@ -241,8 +241,8 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 		transfer_interface = interface;
 		usb_start_receive_ep0_data_stage(
 		                      (char*)&transfer_data.line_coding,
-                              (setup->wLength<sizeof(transfer_data.comm_feature))?
-                                  setup->wLength : sizeof(transfer_data.comm_feature)
+		                      min(setup->wLength,
+		                          sizeof(transfer_data.line_coding)),
 		                      set_line_coding, NULL);
 		return 0;
 	}
@@ -260,8 +260,8 @@ uint8_t process_cdc_setup_request(const struct setup_packet *setup)
 			return -1;
 
 		usb_send_data_stage((char*)&transfer_data.line_coding,
-                            (setup->wLength<sizeof(transfer_data.comm_feature))?
-                                setup->wLength : sizeof(transfer_data.comm_feature)
+		                    min(setup->wLength,
+		                        sizeof(transfer_data.line_coding)),
 		                    /*callback*/NULL, NULL);
 		return 0;
 	}

--- a/usb/src/usb_hal.h
+++ b/usb/src/usb_hal.h
@@ -437,7 +437,7 @@ struct buffer_descriptor {
 #define FAR
 #define memcpy_from_rom(x,y,z) memcpy(x,y,z)
 
-#elif __XC32__
+#elif __XC32__ || (defined(__GNUC__) && __mips == 32)
 
 #define USB_NEEDS_POWER_ON
 #define USB_NEEDS_SET_BD_ADDR_REG

--- a/usb/src/usb_hal.h
+++ b/usb/src/usb_hal.h
@@ -530,7 +530,7 @@ struct buffer_descriptor {
 			uint32_t BSTALL : 1;
 			uint32_t DTSEN : 1;    /* DTS in datasheet */
 			uint32_t reserved : 2; /* NINC, KEEP */
-			uint32_t DTS : 1;      /* DATA0/1 in datasheet */
+			uint32_t /*DTS*/ : 1;  /* DATA0/1 in datasheet */
 			uint32_t /*UOWN*/ : 1;
 
 			uint32_t : 8;

--- a/usb/src/usb_hid.c
+++ b/usb/src/usb_hid.c
@@ -91,7 +91,7 @@ uint8_t process_hid_setup_request(const struct setup_packet *setup)
 		if (len < 0)
 			return -1;
 
-		usb_send_data_stage((void*) desc, min(len, setup->wLength), NULL, NULL);
+		usb_send_data_stage((void*) desc, MIN(len, setup->wLength), NULL, NULL);
 		return 0;
 	}
 
@@ -112,7 +112,7 @@ uint8_t process_hid_setup_request(const struct setup_packet *setup)
 		if (len < 0)
 			return -1;
 
-		usb_send_data_stage((void*)desc, min(len, setup->wLength), callback, context);
+		usb_send_data_stage((void*)desc, MIN(len, setup->wLength), callback, context);
 		return 0;
 	}
 #endif

--- a/usb/src/usb_hid.c
+++ b/usb/src/usb_hid.c
@@ -91,7 +91,8 @@ uint8_t process_hid_setup_request(const struct setup_packet *setup)
 		if (len < 0)
 			return -1;
 
-		usb_send_data_stage((void*) desc, min(len, setup->wLength), NULL, NULL);
+		usb_send_data_stage((void*)desc,
+            (len<setup->wLength)? len : setup->wLength, NULL, NULL);
 		return 0;
 	}
 
@@ -112,7 +113,8 @@ uint8_t process_hid_setup_request(const struct setup_packet *setup)
 		if (len < 0)
 			return -1;
 
-		usb_send_data_stage((void*)desc, min(len, setup->wLength), callback, context);
+		usb_send_data_stage((void*)desc,
+            (len<setup->wLength)? len : setup->wLength, callback, context);
 		return 0;
 	}
 #endif

--- a/usb/src/usb_hid.c
+++ b/usb/src/usb_hid.c
@@ -91,8 +91,7 @@ uint8_t process_hid_setup_request(const struct setup_packet *setup)
 		if (len < 0)
 			return -1;
 
-		usb_send_data_stage((void*)desc,
-            (len<setup->wLength)? len : setup->wLength, NULL, NULL);
+		usb_send_data_stage((void*) desc, min(len, setup->wLength), NULL, NULL);
 		return 0;
 	}
 
@@ -113,8 +112,7 @@ uint8_t process_hid_setup_request(const struct setup_packet *setup)
 		if (len < 0)
 			return -1;
 
-		usb_send_data_stage((void*)desc,
-            (len<setup->wLength)? len : setup->wLength, callback, context);
+		usb_send_data_stage((void*)desc, min(len, setup->wLength), callback, context);
 		return 0;
 	}
 #endif


### PR DESCRIPTION
As previously discussed in issue #14, I was working on supporting a vanilla mipsel GCC toolchain in m-stack. The changes I made are quite minor, but as they're in a working state now I feel it's probably appropriate to get some feedback here.

There are two main things to consider here:

1. How do we detect a vanilla GCC as opposed to Microchip's modified XC32?

    - This may not be the best approach, but I decided to detect a 32-bit MIPS GCC-compatible compiler leave it at that. I haven't run exhaustive tests just yet, but putting these under the XC32 cases seems to work perfectly.

2. How can we get access to C-like declarations of SFRs for M-stack to use?

    - Presumably, if one isn't using Microchip's XC32 compiler it may not be possible to have a standard header (`xc.h`) one can include to get access to useful SFR declarations, such as `U1IR`. However, there is already a standardized way to allow the user to configure things for the library, which is the file `usb_config.h`. As such, I assume now that if using a vanilla compiler, you must include a header file to provide SFR declarations.

Please let me know what you think!

Thank you.