### PR TITLE
Add VID/PID configuration to usb_config.h

### DIFF
--- a/apps/cdc_acm/usb_config.h
+++ b/apps/cdc_acm/usb_config.h
@@ -22,6 +22,14 @@
 #ifndef USB_CONFIG_H__
 #define USB_CONFIG_H__
 
+/* Uncomment these lines only if you have purchased a valid
+ * VID/PID pair.  Do not attempt to use a VID/PID pair that
+ * you do not own or that has not been sub-licensed to you.
+ * A VID/PID pair should only be used for a single device,
+ * and should not be re-used between multiple projects.  */
+//#define MY_VID 0xA0A0
+//#define MY_PID 0x0004
+
 /* Number of endpoint numbers besides endpoint zero. It's worth noting that
    and endpoint NUMBER does not completely describe an endpoint, but the
    along with the DIRECTION does (eg: EP 1 IN).  The #define below turns on

--- a/apps/cdc_acm/usb_descriptors.c
+++ b/apps/cdc_acm/usb_descriptors.c
@@ -29,6 +29,28 @@
 #define ROMPTR
 #endif
 
+/* VID/PID Descriptor Definitions
+ *
+ * Utilize user-defined VID/PID values if provided in usb_config.h
+ * otherwise, defaults are provided by the stack.  The defaults are
+ * only intended for testing purposes, and a unique VID/PID pair
+ * should be provided for an end-product release, otherwise driver
+ * issues may occur due to VID/PID conflicts.
+ */
+#ifdef MY_VID
+#define DESC_VID MY_VID
+#else
+#define DESC_VID 0xA0A0
+#warning "No user-defined VID, using the default instead.  MY_VID should be set in usb_config.h"
+#endif
+
+#ifdef MY_PID
+#define DESC_PID MY_PID
+#else
+#define DESC_PID 0x0004
+#warning "No user-defined PID, using the default instead.  MY_PID should be set in usb_config.h"
+#endif
+
 /* Configuration Packet
  *
  * This packet contains a configuration descriptor, one or more interface
@@ -91,8 +113,8 @@ const ROMPTR struct device_descriptor this_device_descriptor =
 	         Association Descriptor Device Class Code and Use Model" */
 	0x01, // Protocol. See document referenced above.
 	EP_0_LEN, // bMaxPacketSize0
-	0xA0A0, // Vendor
-	0x0004, // Product
+	DESC_VID, // Vendor ID: Defined in usb_config.h
+	DESC_PID, // Product ID: Defined in usb_config.h
 	0x0001, // device release (1.0)
 	1, // Manufacturer
 	2, // Product

--- a/apps/hid_composite/usb_config.h
+++ b/apps/hid_composite/usb_config.h
@@ -22,6 +22,14 @@
 #ifndef USB_CONFIG_H__
 #define USB_CONFIG_H__
 
+/* Uncomment these lines only if you have purchased a valid
+ * VID/PID pair.  Do not attempt to use a VID/PID pair that
+ * you do not own or that has not been sub-licensed to you.
+ * A VID/PID pair should only be used for a single device,
+ * and should not be re-used between multiple projects.  */
+//#define MY_VID 0xA0A0
+//#define MY_PID 0x0003
+
 /* Number of endpoint numbers besides endpoint zero. It's worth noting that
    and endpoint NUMBER does not completely describe an endpoint, but the
    along with the DIRECTION does (eg: EP 1 IN).  The #define below turns on

--- a/apps/hid_composite/usb_descriptors.c
+++ b/apps/hid_composite/usb_descriptors.c
@@ -29,6 +29,28 @@
 #define ROMPTR
 #endif
 
+/* VID/PID Descriptor Definitions
+ *
+ * Utilize user-defined VID/PID values if provided in usb_config.h
+ * otherwise, defaults are provided by the stack.  The defaults are
+ * only intended for testing purposes, and a unique VID/PID pair
+ * should be provided for an end-product release, otherwise driver
+ * issues may occur due to VID/PID conflicts.
+ */
+#ifdef MY_VID
+#define DESC_VID MY_VID
+#else
+#define DESC_VID 0xA0A0
+#warning "No user-defined VID, using the default instead.  MY_VID should be set in usb_config.h"
+#endif
+
+#ifdef MY_PID
+#define DESC_PID MY_PID
+#else
+#define DESC_PID 0x0003
+#warning "No user-defined PID, using the default instead.  MY_PID should be set in usb_config.h"
+#endif
+
 /* Configuration Packet
  *
  * This packet contains a configuration descriptor, one or more interface
@@ -87,8 +109,8 @@ const ROMPTR struct device_descriptor this_device_descriptor =
 	0x00, // Device Subclass
 	0x00, // Protocol.
 	EP_0_LEN, // bMaxPacketSize0
-	0xA0A0, // Vendor
-	0x0003, // Product
+	DESC_VID, // Vendor ID: Defined in usb_config.h
+	DESC_PID, // Product ID: Defined in usb_config.h
 	0x0001, // device release (1.0)
 	1, // Manufacturer
 	2, // Product

--- a/apps/hid_mouse/usb_config.h
+++ b/apps/hid_mouse/usb_config.h
@@ -22,6 +22,14 @@
 #ifndef USB_CONFIG_H__
 #define USB_CONFIG_H__
 
+/* Uncomment these lines only if you have purchased a valid
+ * VID/PID pair.  Do not attempt to use a VID/PID pair that
+ * you do not own or that has not been sub-licensed to you.
+ * A VID/PID pair should only be used for a single device,
+ * and should not be re-used between multiple projects.  */
+//#define MY_VID 0xA0A0
+//#define MY_PID 0x0003
+
 /* Number of endpoint numbers besides endpoint zero. It's worth noting that
    and endpoint NUMBER does not completely describe an endpoint, but the
    along with the DIRECTION does (eg: EP 1 IN).  The #define below turns on

--- a/apps/hid_mouse/usb_descriptors.c
+++ b/apps/hid_mouse/usb_descriptors.c
@@ -29,6 +29,28 @@
 #define ROMPTR
 #endif
 
+/* VID/PID Descriptor Definitions
+ *
+ * Utilize user-defined VID/PID values if provided in usb_config.h
+ * otherwise, defaults are provided by the stack.  The defaults are
+ * only intended for testing purposes, and a unique VID/PID pair
+ * should be provided for an end-product release, otherwise driver
+ * issues may occur due to VID/PID conflicts.
+ */
+#ifdef MY_VID
+#define DESC_VID MY_VID
+#else
+#define DESC_VID 0xA0A0
+#warning "No user-defined VID, using the default instead.  MY_VID should be set in usb_config.h"
+#endif
+
+#ifdef MY_PID
+#define DESC_PID MY_PID
+#else
+#define DESC_PID 0x0003
+#warning "No user-defined PID, using the default instead.  MY_PID should be set in usb_config.h"
+#endif
+
 /* Configuration Packet
  *
  * This packet contains a configuration descriptor, one or more interface
@@ -80,8 +102,8 @@ const ROMPTR struct device_descriptor this_device_descriptor =
 	0x00, // Device Subclass
 	0x00, // Protocol.
 	EP_0_LEN, // bMaxPacketSize0
-	0xA0A0, // Vendor
-	0x0003, // Product
+	DESC_VID, // Vendor ID: Defined in usb_config.h
+	DESC_PID, // Product ID: Defined in usb_config.h
 	0x0001, // device release (1.0)
 	1, // Manufacturer
 	2, // Product

--- a/apps/msc_test/usb_config.h
+++ b/apps/msc_test/usb_config.h
@@ -22,6 +22,14 @@
 #ifndef USB_CONFIG_H__
 #define USB_CONFIG_H__
 
+/* Uncomment these lines only if you have purchased a valid
+ * VID/PID pair.  Do not attempt to use a VID/PID pair that
+ * you do not own or that has not been sub-licensed to you.
+ * A VID/PID pair should only be used for a single device,
+ * and should not be re-used between multiple projects.  */
+//#define MY_VID 0xA0A0
+//#define MY_PID 0x0005
+
 /* Number of endpoint numbers besides endpoint zero. It's worth noting that
    and endpoint NUMBER does not completely describe an endpoint, but the
    along with the DIRECTION does (eg: EP 1 IN).  The #define below turns on

--- a/apps/msc_test/usb_descriptors.c
+++ b/apps/msc_test/usb_descriptors.c
@@ -29,6 +29,28 @@
 #define ROMPTR
 #endif
 
+/* VID/PID Descriptor Definitions
+ *
+ * Utilize user-defined VID/PID values if provided in usb_config.h
+ * otherwise, defaults are provided by the stack.  The defaults are
+ * only intended for testing purposes, and a unique VID/PID pair
+ * should be provided for an end-product release, otherwise driver
+ * issues may occur due to VID/PID conflicts.
+ */
+#ifdef MY_VID
+#define DESC_VID MY_VID
+#else
+#define DESC_VID 0xA0A0
+#warning "No user-defined VID, using the default instead.  MY_VID should be set in usb_config.h"
+#endif
+
+#ifdef MY_PID
+#define DESC_PID MY_PID
+#else
+#define DESC_PID 0x0005
+#warning "No user-defined PID, using the default instead.  MY_PID should be set in usb_config.h"
+#endif
+
 /* Configuration Packet
  *
  * This packet contains a configuration descriptor, one or more interface
@@ -79,8 +101,8 @@ const ROMPTR struct device_descriptor this_device_descriptor =
 	0x00, // Device Subclass
 	0x00, // Protocol.
 	EP_0_LEN, // bMaxPacketSize0
-	0xA0A0, // Vendor
-	0x0005, // Product
+	DESC_VID, // Vendor ID: Defined in usb_config.h
+	DESC_PID, // Product ID: Defined in usb_config.h
 	0x0001, // device release (1.0)
 	1, // Manufacturer
 	2, // Product


### PR DESCRIPTION
This adds VID and PID configuration options is usb_config.h, and produces a compiler warning if they are not supplied, in order to alert users if they attempt to build their own projects without supplying their own VID/PID pair.