### PR TITLE
Added support for XC8 2.0 and PIC18F2455

### DIFF
--- a/host_test/control_transfer_in.c
+++ b/host_test/control_transfer_in.c
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
 	if (libusb_init(NULL))
 		return -1;
 
-	handle = libusb_open_device_with_vid_pid(NULL, 0xa0a0, 0x0001);
+	handle = libusb_open_device_with_vid_pid(NULL, 0xa0a0, 0x0003);
 	if (!handle) {
 		perror("libusb_open failed: ");
 		return 1;

--- a/host_test/control_transfer_out.c
+++ b/host_test/control_transfer_out.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 	if (libusb_init(NULL))
 		return -1;
 
-	handle = libusb_open_device_with_vid_pid(NULL, 0xa0a0, 0x0001);
+	handle = libusb_open_device_with_vid_pid(NULL, 0xa0a0, 0x0003);
 	if (!handle) {
 		perror("libusb_open failed: ");
 		return 1;

--- a/host_test/test.c
+++ b/host_test/test.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 	if (libusb_init(NULL))
 		return -1;
 
-	handle = libusb_open_device_with_vid_pid(NULL, 0xa0a0, 0x0001);
+	handle = libusb_open_device_with_vid_pid(NULL, 0xa0a0, 0x0003);
 	if (!handle) {
 		perror("libusb_open failed: ");
 		return 1;

--- a/usb/include/usb_cdc.h
+++ b/usb/include/usb_cdc.h
@@ -42,6 +42,10 @@
 #if defined(__XC16__) || defined(__XC32__)
 #pragma pack(push, 1)
 #elif __XC8
+    #if __XC8_VERSION >= 2000
+	// This is needed, even though the XC8 manual says its unnecessary
+	#pragma pack(push, 1)
+    #endif
 #else
 #error "Compiler not supported"
 #endif

--- a/usb/include/usb_ch9.h
+++ b/usb/include/usb_ch9.h
@@ -41,6 +41,10 @@
 #if defined(__XC16__) || defined(__XC32__)
 #pragma pack(push, 1)
 #elif __XC8
+    #if __XC8_VERSION >= 2000
+	// This is needed, even though the XC8 manual says its unnecessary
+	#pragma pack(push, 1)
+    #endif
 #else
 #error "Compiler not supported"
 #endif

--- a/usb/include/usb_hid.h
+++ b/usb/include/usb_hid.h
@@ -42,6 +42,10 @@
 #if defined(__XC16__) || defined(__XC32__)
 #pragma pack(push, 1)
 #elif __XC8
+    #if __XC8_VERSION >= 2000
+	// This is needed, even though the XC8 manual says its unnecessary
+	#pragma pack(push, 1)
+    #endif
 #else
 #error "Compiler not supported"
 #endif

--- a/usb/include/usb_microsoft.h
+++ b/usb/include/usb_microsoft.h
@@ -41,6 +41,10 @@
 #if defined(__XC16__) || defined(__XC32__)
 #pragma pack(push, 1)
 #elif __XC8
+    #if __XC8_VERSION >= 2000
+	// This is needed, even though the XC8 manual says its unnecessary
+	#pragma pack(push, 1)
+    #endif
 #else
 #error "Compiler not supported"
 #endif

--- a/usb/include/usb_msc.h
+++ b/usb/include/usb_msc.h
@@ -42,6 +42,10 @@
 #if defined(__XC16__) || defined(__XC32__)
 #pragma pack(push, 1)
 #elif __XC8
+    #if __XC8_VERSION >= 2000
+	// This is needed, even though the XC8 manual says its unnecessary
+	#pragma pack(push, 1)
+    #endif
 #else
 #error "Compiler not supported"
 #endif

--- a/usb/src/usb_hal.h
+++ b/usb/src/usb_hal.h
@@ -25,7 +25,7 @@
  */
 
 #ifndef USB_HAL_H__
-#define UAB_HAL_H__
+#define USB_HAL_H__
 
 #ifdef _PIC14E
 #define NEEDS_PULL /* Whether to pull up D+/D- with SFR_PULL_EN. */
@@ -288,7 +288,14 @@ struct buffer_descriptor {
 #ifdef _18F46J50
 #define BD_ADDR 0x400
 //#undef BUFFER_ADDR
-#else
+#endif
+
+#ifdef _18F2455
+    #define BD_ADDR 0x400
+    #define BUFFER_ADDR 0x500
+#endif
+
+#ifndef BD_ADDR
 #error "CPU not supported yet"
 #endif
 
@@ -306,11 +313,19 @@ struct buffer_descriptor {
 #elif defined __XC8
 	#define memcpy_from_rom(x,y,z) memcpy(x,y,z)
 	#define FAR
-	#define BD_ATTR_TAG @##BD_ADDR
-	#ifdef BUFFER_ADDR
-		#define XC8_BUFFER_ADDR_TAG @##BUFFER_ADDR
+	#if __XC8_VERSION >= 2000
+	  // XC8 discontinued the @addr notation and replaced it with __at()
+	  #define AT_ADDR(X) __at(X)
 	#else
-		#define XC8_BUFFER_ADDR_TAG
+	  #define AT_ADDR(X) @X
+	#endif
+
+	#define BD_ATTR_TAG AT_ADDR(BD_ADDR)
+
+	#ifdef BUFFER_ADDR
+	  #define XC8_BUFFER_ADDR_TAG AT_ADDR(BUFFER_ADDR)
+	#else
+	  #define XC8_BUFFER_ADDR_TAG
 	#endif
 #endif
 

--- a/usb/src/usb_hid.c
+++ b/usb/src/usb_hid.c
@@ -91,7 +91,7 @@ uint8_t process_hid_setup_request(const struct setup_packet *setup)
 		if (len < 0)
 			return -1;
 
-		usb_send_data_stage((void*) desc, min(len, setup->wLength), NULL, NULL);
+		usb_send_data_stage((void*) desc, MIN(len, setup->wLength), NULL, NULL);
 		return 0;
 	}
 
@@ -112,7 +112,7 @@ uint8_t process_hid_setup_request(const struct setup_packet *setup)
 		if (len < 0)
 			return -1;
 
-		usb_send_data_stage((void*)desc, min(len, setup->wLength), callback, context);
+		usb_send_data_stage((void*)desc, MIN(len, setup->wLength), callback, context);
 		return 0;
 	}
 #endif


### PR DESCRIPTION
Thanks for writing this! Here's a contribution

I updated some of the macros to work with the latest XC8 (v2.0 and later) since it adheres more closely with C99, and it sheds some of the old notation.  It also requires pragma pack because it seems to want 16-bit alignment (regardless of what the manual says). 

I added support for PIC18F2455, which I'm working with right now.  Seems to work so far.